### PR TITLE
Test enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 .idea/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     }
   },
   "require": {
-    "php": ">=5.6"
+    "php": ">=7.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.6"
+    "phpunit/phpunit": "^8.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,40 +1,42 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5921983e7546c6c9d33db3a28c734a2c",
+    "content-hash": "8c4cd3a038f2bdfde4ad8fe99f9617b9",
     "packages": [],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -54,46 +56,66 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T17:27:14+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.1",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^7.1 || ^8.0"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
-                }
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -101,27 +123,33 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12T18:52:22+00:00"
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-29T13:22:24+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
             },
             "type": "library",
             "extra": {
@@ -130,10 +158,107 @@
                 }
             },
             "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -155,86 +280,91 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2020-06-27T09:03:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2020-02-22T12:28:44+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e878a14a65245fbe78f8080eba03b47c3b705651",
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -247,42 +377,43 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2020-06-27T10:12:23+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1|^2.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpspec/phpspec": "^2.5 || ^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -310,44 +441,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
+            "version": "7.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f1884187926fbb755a9aaf0b3836ad3165b478bf",
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
+                "php": "^7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.1.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "ext-xdebug": "^2.1.4",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -362,7 +493,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -373,29 +504,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02T07:44:40+00:00"
+            "time": "2019-11-20T13:55:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -410,7 +544,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -420,7 +554,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -465,28 +599,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -501,7 +635,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -510,33 +644,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -559,55 +693,56 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2019-09-17T06:23:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.20",
+            "version": "8.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3cb94a5f8c07a03c8b7527ed7468a2926203f58b"
+                "reference": "34c18baa6a44f1d1fbf0338907139e9dce95b997"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3cb94a5f8c07a03c8b7527ed7468a2926203f58b",
-                "reference": "3cb94a5f8c07a03c8b7527ed7468a2926203f58b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/34c18baa6a44f1d1fbf0338907139e9dce95b997",
+                "reference": "34c18baa6a44f1d1fbf0338907139e9dce95b997",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0.3|~2.0",
-                "symfony/yaml": "~2.1|~3.0"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.2",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^7.0.7",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/exporter": "^3.1.1",
+                "sebastian/global-state": "^3.0.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
+                "sebastian/version": "^2.0.1"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -615,7 +750,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -641,66 +776,17 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-05-22T07:42:55+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "time": "2016-12-08T20:27:08+00:00"
+            "time": "2020-06-22T07:06:58+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -749,30 +835,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -803,38 +889,39 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -859,34 +946,40 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -911,34 +1004,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2019-11-20T08:46:58+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "2.0.0",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -952,6 +1045,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -960,16 +1057,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -978,27 +1071,30 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2019-09-14T09:02:43+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1006,7 +1102,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1029,33 +1125,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2019-02-01T05:30:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1075,32 +1172,77 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "2.0.0",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1128,29 +1270,29 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1170,7 +1312,53 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2019-07-02T08:10:15+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1216,40 +1404,41 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.3.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "885db865f6b2b918404a1fae28f9ac640f71f994"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/885db865f6b2b918404a1fae28f9ac640f71f994",
-                "reference": "885db865f6b2b918404a1fae28f9ac640f71f994",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
+                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "symfony/console": "~2.8|~3.0"
+                "php": ">=5.3.3"
             },
             "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "ext-ctype": "For best performance"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
+                    "Symfony\\Polyfill\\Ctype\\": ""
                 },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "files": [
+                    "bootstrap.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1258,45 +1447,104 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Yaml Component",
+            "description": "Symfony polyfill for ctype functions",
             "homepage": "https://symfony.com",
-            "time": "2017-05-28T10:56:20+00:00"
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
             },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/9dc4f203e36f2b486149058bade43c851dd97451",
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -1318,7 +1566,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2020-06-16T10:16:42+00:00"
         }
     ],
     "aliases": [],
@@ -1327,7 +1575,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6"
+        "php": ">=7.2"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,5 @@
-<phpunit bootstrap="vendor/autoload.php" color="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="license-plates">
             <directory>tests</directory>

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/AbstractGermanyPlate.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/AbstractGermanyPlate.php
@@ -2,13 +2,14 @@
 
 namespace PBurggraf\LicensePlate\Test\Detector\Germany;
 
+use PHPUnit\Framework\TestCase;
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
 use PBurggraf\LicensePlate\LicensePlateFactory;
 
 /**
  * @author Philip Burggraf <philip@pburggraf.de>
  */
-abstract class AbstractGermanyPlate extends \PHPUnit_Framework_TestCase
+abstract class AbstractGermanyPlate extends TestCase
 {
     /**
      * @var array

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateATest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateATest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Test\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 
 /**
  * @author Philip Burggraf <philip@pburggraf.de>

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateAbTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateAbTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateAnTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateAnTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBaTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBaTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBhTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBhTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBkTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBkTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBsTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBsTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBtTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBtTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBulTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateBulTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateDdTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateDdTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateEbsTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateEbsTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateEfTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateEfTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateEsbTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateEsbTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateFueTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateFueTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateGeoTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateGeoTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateGoeTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateGoeTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateHTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateHTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateHbTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateHbTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateHoTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateHoTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateKaTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateKaTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateLTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateLTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateLaTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateLaTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateLgTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateLgTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateMTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateMTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateMaiTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateMaiTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateMalTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateMalTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateMuebTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateMuebTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateMzTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateMzTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateNTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateNTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateNabTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateNabTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateOlTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateOlTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateOsTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateOsTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlatePaTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlatePaTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateParTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateParTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlatePegTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlatePegTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateRTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateRTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateRehTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateRehTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateRoTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateRoTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateRodTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateRodTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**
@@ -129,7 +128,7 @@ class PlateRodTest extends AbstractGermanyPlate
             ],
             'type' => GermanyDetector::PLATE_TYPE_DEFAULT,
         ],
-        
+
         [
             'plate' => 'ROD G 1',
             'description' => [
@@ -215,7 +214,7 @@ class PlateRodTest extends AbstractGermanyPlate
             ],
             'type' => GermanyDetector::PLATE_TYPE_DEFAULT,
         ],
-        
+
         [
             'plate' => 'ROD AA 1',
             'description' => [

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateRolTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateRolTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateSanTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateSanTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateSrTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateSrTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateSwTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateSwTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateVibTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateVibTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateWerTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateWerTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateWiTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateWiTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateWueTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateWueTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/Detector/Germany/PlateZwTest.php
+++ b/tests/PBurggraf/LicensePlate/Detector/Germany/PlateZwTest.php
@@ -3,7 +3,6 @@
 namespace PBurggraf\LicensePlate\Detector\Germany;
 
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
-use PBurggraf\LicensePlate\LicensePlateFactory;
 use PBurggraf\LicensePlate\Test\Detector\Germany\AbstractGermanyPlate;
 
 /**

--- a/tests/PBurggraf/LicensePlate/GermanyDetectorTest.php
+++ b/tests/PBurggraf/LicensePlate/GermanyDetectorTest.php
@@ -2,13 +2,14 @@
 
 namespace PBurggraf\LicensePlate\Test\Detector;
 
+use PHPUnit\Framework\TestCase;
 use PBurggraf\LicensePlate\Detector\GermanyDetector;
 use PBurggraf\LicensePlate\LicensePlateFactory;
 
 /**
  * @author Philip Burggraf <philip@pburggraf.de>
  */
-class GermanyDetectorTest extends \PHPUnit_Framework_TestCase
+class GermanyDetectorTest extends TestCase
 {
     protected static $plateTests = [
         [
@@ -331,6 +332,8 @@ class GermanyDetectorTest extends \PHPUnit_Framework_TestCase
             $result = $validationResult->isValid();
             $this->assertEquals($validity, $result, sprintf('Tested plate: \'%s\', should be %s', $plate, (bool)$validity));
         }
+
+        $this->assertGreaterThanOrEqual(0, count($validationResults));
     }
 
     /**
@@ -348,6 +351,8 @@ class GermanyDetectorTest extends \PHPUnit_Framework_TestCase
             $result = $typeResult->getType();
             $this->assertEquals($type, $result, sprintf('Tested plate: \'%s\', should be %s', $plate, $type));
         }
+
+        $this->assertGreaterThanOrEqual(0, count($typeResults));
     }
 
     /**

--- a/tests/PBurggraf/LicensePlate/NetherlandsDetectorTest.php
+++ b/tests/PBurggraf/LicensePlate/NetherlandsDetectorTest.php
@@ -2,10 +2,11 @@
 
 namespace PBurggraf\LicensePlate\Test\Detector;
 
+use PHPUnit\Framework\TestCase;
 use PBurggraf\LicensePlate\Detector\NetherlandsDetector;
 use PBurggraf\LicensePlate\LicensePlateFactory;
 
-class NetherlandsDetectorTest extends \PHPUnit_Framework_TestCase
+class NetherlandsDetectorTest extends TestCase
 {
     protected static $plateTests = [
         [


### PR DESCRIPTION
# Changed log
- Since the `php-5.6`, `php-7.0` and `php-7.1` versions are going to be inactive. Using the `php-7.2` version for this package at least.
- Using the `PHPUnit\Framework\TestCase` namespace for upgrading PHPUnit `8.x` version.
- Upgrading the cached dependencies with `composer update` command.
- Removing unused use syntax because this namespace is defined with `use`, but not used.
- Removing additional white spaces because they're useless.
- 